### PR TITLE
feature: add support to Kangal environment variables files

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,9 @@ export LOAD_TEST_REPORT_ERRORS_ITEMS_2_PERCENT_IN_SAMPLES=0
 * `overwrite`: Overwrite the load test if exists. Possible values: `true` or `false`
 * `type`: Load test type.
 
+###### Optional
+* `vars`: The path to environment variables file.
+
 Those parameters will be used to create load test with this API call.
 
 The load test will be tagged with `tags` in `source` configuration plus current timestamp in nanoseconds (in order to sort the versions).
@@ -232,7 +235,8 @@ curl -X POST http://${KANGAL_PROXY_ADDRESS}/load-test \
   -F testData=@${data} \
   -F tags=${tags} \
   -F type=${type} \
-  -F overwrite=${overwrite}
+  -F overwrite=${overwrite} \
+  -F envVars=@${vars}
 ```
 
 ## Usage
@@ -294,5 +298,6 @@ jobs:
       params:
         plan: load-tests/testplan.jmx
         data: load-tests/testdata.csv
+        vars: load-tests/envVars.csv
         pods: "9"
 ```

--- a/assets/out
+++ b/assets/out
@@ -27,6 +27,7 @@ cat > "$payload" <&0
 proxyHost=$(jq -r '.source.proxy_host // ""' < "$payload")
 plan=$(jq -r '.params.plan // ""' < "$payload")
 data=$(jq -r '.params.data // ""' < "$payload")
+vars=$(jq -r '.params.vars // ""' < "$payload")
 distributedPods=$(jq -r '.params.pods // 1' < "$payload")
 tags=$(\
     jq -c -M -r \
@@ -49,10 +50,16 @@ if [ -n "$data" ] && [ ! -f "$data" ]; then
     exit 1
 fi
 
+if [ -n "$vars" ] && [ ! -f "$vars" ]; then
+    echo "environment variables file '$vars' does not exist"
+    exit 1
+fi
+
 if [[ -n "$proxyHost" ]]; then
     KANGAL_PROXY_HOST="$proxyHost"
 fi
 
+# Printing inputs
 echo "KANGAL_PROXY_HOST: $KANGAL_PROXY_HOST"
 echo "LOAD_TEST_FILE: $plan"
 echo "LOAD_TEST_DATA: $data"
@@ -60,6 +67,12 @@ echo "LOAD_TEST_DISTRIBUTED_PODS: $distributedPods"
 echo "LOAD_TEST_TAGS: $tags"
 echo "LOAD_TEST_TYPE: $type"
 echo "LOAD_TEST_OVERWRITE: $overwrite"
+
+# Optionals
+if [ -n "$vars" ]; then
+    echo "LOAD_TEST_ENV_VARS: $vars"
+fi
+
 echo
 
 if [ -n "$data" ]; then
@@ -72,16 +85,23 @@ if [ -n "$data" ]; then
     echo
 fi
 
-cat <<EOF
-curl -vvv -s "http://$KANGAL_PROXY_HOST/load-test" \
-    -H 'Content-Type: multipart/form-data'
-    -F distributedPods="$distributedPods" \
-    -F testFile=@"$plan" \
-    -F testData=@"$data" \
-    -F tags="$tags" \
-    -F type="$type" \
-    -F overwrite="$overwrite"
-EOF
+req="
+curl -vvv -s http://$KANGAL_PROXY_HOST/load-test
+  -H 'Content-Type: multipart/form-data'
+  -F distributedPods=$distributedPods
+  -F testFile=@$plan
+  -F testData=@$data
+  -F tags=$tags
+  -F type=$type
+  -F overwrite=$overwrite
+"
+
+opt=""
+if [ -n "$vars" ]; then
+    opt="$opt -F envVars=@$vars"
+fi
+
+echo "executing: $req $opt"
 
 echo
 
@@ -94,6 +114,7 @@ loadtest=$(\
         -F tags="$tags" \
         -F type="$type" \
         -F overwrite="$overwrite" \
+        $opt
 )
 
 echo


### PR DESCRIPTION
## Description
Kangal also supports loading environment variables.

This PR is introducing the `vars` parameter as optional.

     - put: run
      resource: my-load-tests
      params:
        plan: load-tests/testplan.jmx
        data: load-tests/testdata.csv
        vars: load-tests/envVars.csv

`vars` property is translated to envVars in Kangal request `-F envVars=@$vars`

* request without `vars` param:
`curl -vvv -s http://$KANGAL_PROXY_HOST/load-test
    -H 'Content-Type: multipart/form-data'
    -F distributedPods=$distributedPods
    -F testFile=@$plan
    -F testData=@$data
    -F tags=$tags
    -F type=$type
    -F overwrite=$overwrite`

* request with `vars` param:
`curl -vvv -s http://$KANGAL_PROXY_HOST/load-test
    -H 'Content-Type: multipart/form-data'
    -F distributedPods=$distributedPods
    -F testFile=@$plan
    -F testData=@$data
    -F tags=$tags
    -F type=$type
    -F overwrite=$overwrite
    -F envVars=@$vars
`

### output sample:

    KANGAL_PROXY_HOST: kangal.tools-k8s.hellofresh.io
    LOAD_TEST_FILE: /test/testplan.jmx
    LOAD_TEST_DATA: /test/testdata.csv
    LOAD_TEST_DISTRIBUTED_PODS: 1
    LOAD_TEST_TAGS: 
    LOAD_TEST_TYPE: JMeter
    LOAD_TEST_OVERWRITE: true
    LOAD_TEST_ENV_VARS: /test/envVars.csv

    Data Lines:
        499 /test/testdata.csv

    Data Size:
        20K    /test/testdata.csv


     curl -vvv -s http://kangal.tools-k8s.hellofresh.io/load-test   -H 'Content-Type: multipart/form-data'   -F distributedPods=1   -F testFile=@/test/testplan.jmx   -F testData=@/test/testdata.csv   -F tags=   -F type=JMeter   -F overwrite=true  -F envVars=@/test/envVars.csv 

    *   Trying 172.21.35.81...
    * TCP_NODELAY set
    * Connected to kangal.tools-k8s.hellofresh.io (172.21.35.81) port 80 (#0)
    > POST /load-test HTTP/1.1
    > Host: kangal.tools-k8s.hellofresh.io
    > User-Agent: curl/7.64.1
    > Accept: */*
    > Content-Length: 38459
    > Content-Type: multipart/form-data; boundary=------------------------f05ab23b0f7bec9b
    > Expect: 100-continue
    > 
    < HTTP/1.1 100 Continue
     [38459 bytes data]
    * We are completely uploaded and fine
    < HTTP/1.1 201 Created
    < Content-Type: application/json; charset=utf-8
     Date: Fri, 20 Nov 2020 15:19:10 GMT
    < Vary: Origin
     Content-Length: 144
    < Connection: keep-alive
    < 
    { [144 bytes data]
    * Connection #0 to host kangal.tools-k8s.hellofresh.io left intact
    * Closing connection 0
    {"type":"JMeter","distributedPods":1,"loadtestName":"loadtest-sweet-panther","phase":"creating","tags":{},"hasEnvVars":true,"hasTestData":true}
    {"type":"JMeter","distributedPods":1,"loadtestName":"loadtest-sweet-panther","phase":"creating","tags":{},"hasEnvVars":true,"hasTestData":true}

    loadtest-sweet-panther
    {
      "version": {
        "type": "JMeter",
        "loadtestName": "loadtest-sweet-panther",
        "distributedPods": "1",
        "tags": "",
        "timestamp": ""
      },
      "metadata": [
        {
          "name": "type",
          "value": "JMeter"
        },
        {
          "name": "loadtestName",
          "value": "loadtest-sweet-panther"
        },
        {
          "name": "distributedPods",
          "value": "1"
        },
        {
          "name": "tags",
          "value": ""
        },
        {
          "name": "timestamp",
          "value": ""
        }
      ]
    }
    {"version":{"type":"JMeter","loadtestName":"loadtest-sweet-panther","distributedPods":"1","tags":"","timestamp":""},"metadata":[{"name":"type","value":"JMeter"},{"name":"loadtestName","value":"loadtest-sweet-panther"},{"name":"distributedPods","value":"1"},{"name":"tags","value":""},{"name":"timestamp","value":""}]}